### PR TITLE
Refactor the PDF generation slightly

### DIFF
--- a/client/src/app/pdf.service.spec.ts
+++ b/client/src/app/pdf.service.spec.ts
@@ -1,4 +1,27 @@
-import { PDFService, RealJsPDF } from './pdf.service';
+import { PDFService } from './pdf.service';
+import * as jsPDF from 'jspdf';
+
+/**
+ * This is the jsPDF type, but with more of its methods exposed.
+ *
+ * jspdf, the library, clearly distinguishes between its public API and its
+ * private, internal API.
+ *
+ * Now, the @types/jspdf module, which provides type declarations for using
+ * jspdf in TypeScript, chooses not to expose methods of the jsPDF class
+ * that are part of the public API, but that don't have any documentation.
+ *
+ * This is the wrong decision; those methods are designated for public use and
+ * should not be hidden just because their documentation is incomplete.
+ *
+ * So, here, we declare a new TypeScript type that includes all of the methods
+ * declared in @types/jspdf, plus certain methods that @types/jspdf hides, but
+ * that we use here anyway.
+ */
+type RealJsPDF = jsPDF & {
+  getNumberOfPages: () => number,
+};
+
 
 describe('The PDF Service:', () => {
   describe('The getPDF() method:', () => {
@@ -7,7 +30,7 @@ describe('The PDF Service:', () => {
 
     beforeEach(() => {
       pdfService = new PDFService();
-      doc = pdfService.getPDF();
+      doc = pdfService.getPDF() as RealJsPDF;
     });
 
     it('makes a document with exactly one page', () => {

--- a/client/src/app/pdf.service.ts
+++ b/client/src/app/pdf.service.ts
@@ -2,26 +2,6 @@ import { Injectable } from '@angular/core';
 import { environment } from '../environments/environment';
 import * as jsPDF from 'jspdf';
 
-/**
- * This is the jsPDF type, but with more of its methods exposed.
- *
- * jspdf, the library, clearly distinguishes between its public API and its
- * private, internal API.
- *
- * Now, the @types/jspdf module, which provides type declarations for using
- * jspdf in TypeScript, chooses not to expose methods of the jsPDF class
- * that are part of the public API, but that don't have any documentation.
- *
- * This is the wrong decision; those methods are designated for public use and
- * should not be hidden just because their documentation is incomplete.
- *
- * So, here, we declare a new TypeScript type that includes all of the methods
- * declared in @types/jspdf, plus certain methods that @types/jspdf hides, but
- * that we use here anyway.
- */
-export type RealJsPDF = jsPDF & {
-  getNumberOfPages: () => number,
-};
 
 @Injectable()
 export class PDFService {
@@ -32,14 +12,14 @@ export class PDFService {
    * Returns a jsPDF object with a link to Professor Rachel's
    * DoorBoard viewer page.
    */
-  getPDF(): RealJsPDF {
+  getPDF(): jsPDF {
     const url: string = environment.BASE_URL + '/viewer';
 
     const doc = new jsPDF({
       orientation: 'portrait',
       unit: 'in',
       format: 'letter',
-    }) as RealJsPDF;
+    });
 
     doc.setFontSize(18);
     doc.text('Rachel Johnson\'s DoorBoard', (8.5 / 2), 0.5, { align: 'center' });

--- a/client/src/testing/pdf.service.mock.ts
+++ b/client/src/testing/pdf.service.mock.ts
@@ -1,17 +1,18 @@
 import { Injectable } from '@angular/core';
-import { PDFService, RealJsPDF } from '../app/pdf.service';
+import { PDFService } from '../app/pdf.service';
+import * as jsPDF from 'jspdf';
 
 @Injectable()
 export class MockPDFService extends PDFService {
   // Mock a jsPDF document. We can poke at it later, to see
   // what methods have been called on it.
-  public doc: RealJsPDF = jasmine.createSpyObj('doc', ['save']);
+  public doc: jsPDF = jasmine.createSpyObj('doc', ['save']);
 
   constructor() {
     super();
   }
 
-  getPDF(): RealJsPDF {
+  getPDF(): jsPDF {
     return this.doc;
   }
 }


### PR DESCRIPTION
Move RealJsPDF type from application code into test code.

This pull request removes RealJsPDF from the application code and moves it into the pdf.service.spec.ts file exclusively.

The RealJsPDF type exposes functionality that is only needed in test code. It's also a bit of a messy hack. As a rule, that sort of messiness should be confined to as narrow a scope as possible. So, as of now, we're only using it in test code.