### PR TITLE
Make notes expand as necessary vertically

### DIFF
--- a/client/src/app/home/home.component.scss
+++ b/client/src/app/home/home.component.scss
@@ -6,6 +6,7 @@
   flex-wrap: wrap;
   justify-content: center;
 }
+
 .add-note-fab {
   position: fixed;
   bottom: 15px;
@@ -14,7 +15,7 @@
 
 .note-card {
   width: 200px;
-  height: 200px;
+  min-height: 200px;
   margin: 10px;
   position: relative;
   background-color: palegoldenrod;


### PR DESCRIPTION
So that we don't have text overflowing the note. (If the body does *not* fill the whole note, then the note stays 200px. It doesn't shrink, but it does grow if it needs to.)

Otherwise you have stuff like this:
<img width="256" alt="Screen Shot 2020-03-10 at 7 34 36 PM" src="https://user-images.githubusercontent.com/56209343/76371391-1f0c2800-6308-11ea-947d-7f23b5b3df09.png">
