### PR TITLE
Put all the notes-related CSS in one place.

### DIFF
--- a/client/src/app/home/home.component.scss
+++ b/client/src/app/home/home.component.scss
@@ -1,25 +1,9 @@
-.note-container {
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-}
+@import '../notes.scss';
 
-.add-note-fab {
-  position: fixed;
-  bottom: 15px;
-  right: 30px;
-}
-
+/**
+ * Modify the note card so it has a little action-bar at the bottom
+ */
 .note-card {
-  width: 200px;
-  min-height: 200px;
-  margin: 10px;
-  position: relative;
-  background-color: palegoldenrod;
-
   display: flex;
   flex-direction: column;
 }
@@ -34,6 +18,12 @@
   justify-content: flex-end;
 }
 
+.add-note-fab {
+  position: fixed;
+  bottom: 15px;
+  right: 30px;
+}
+
 p {
   font-size: 15px;
 }
@@ -41,9 +31,4 @@ p {
 h2 {
   text-align: center;
   text-decoration: underline;
-}
-
-.note-error {
-  text-align: center;
-  padding: 10px;
 }

--- a/client/src/app/notes.scss
+++ b/client/src/app/notes.scss
@@ -1,0 +1,25 @@
+/**
+ * Common formatting for notes on the viewer page and the owner page.
+ */
+
+.note-container {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.note-card {
+  width: 200px;
+  min-height: 200px;
+  margin: 10px;
+  position: relative;
+  background-color: palegoldenrod;
+}
+
+.note-error {
+  text-align: center;
+  padding: 10px;
+}

--- a/client/src/app/pdf.service.ts
+++ b/client/src/app/pdf.service.ts
@@ -23,7 +23,6 @@ export class PDFService {
 
     doc.setFontSize(18);
     doc.text('Rachel Johnson\'s DoorBoard', (8.5 / 2), 0.5, { align: 'center' });
-    // TODO: hook up the production IP address for deployment.
     doc.text(url, (8.5 / 2), 1, { align: 'center' });
 
     return doc;

--- a/client/src/app/viewer-page/viewer-page.component.scss
+++ b/client/src/app/viewer-page/viewer-page.component.scss
@@ -1,19 +1,4 @@
-.note-container {
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-}
-
-.note-card {
-  width: 200px;
-  min-height: 200px;
-  margin: 10px;
-  position: relative;
-  background-color: palegoldenrod;
-}
+@import '../notes.scss';
 
 p {
   font-size: 15px;
@@ -22,9 +7,4 @@ p {
 h2 {
   text-align: center;
   text-decoration: underline;
-}
-
-.note-error {
-  text-align: center;
-  padding: 10px;
 }

--- a/client/src/app/viewer-page/viewer-page.component.scss
+++ b/client/src/app/viewer-page/viewer-page.component.scss
@@ -9,7 +9,7 @@
 
 .note-card {
   width: 200px;
-  height: 200px;
+  min-height: 200px;
   margin: 10px;
   position: relative;
   background-color: palegoldenrod;


### PR DESCRIPTION
Previously, the css for notes on the viewer page and the owner pager weren't in sync. (In particular, the viewer page have the fix from pull request #30.)

If this pull request is accepted, both pages will import a common set of CSS rules from a file named `notes.scss`. (The owner page will add some additional formatting for delete-buttons and stuff like that.)

Also, this pull request cleans up some old comments that were out-of-date.