### PR TITLE
Get rid of the nav-bar

### DIFF
--- a/client/e2e/src/app.e2e-spec.ts
+++ b/client/e2e/src/app.e2e-spec.ts
@@ -15,16 +15,4 @@ describe('App', () => {
     page.navigateTo();
     expect(page.getAppTitle()).toEqual('DoorBoard');
   });
-
-  it('Should open the sidenav', () => {
-    page.navigateTo();
-
-    // Before clicking on the button, the sidenav should be hidden
-    expect(page.getSidenav().isDisplayed()).toBe(false);
-
-    page.openSideNav().then(() => {
-      // After clicking the button the sidenav should be displayed
-      expect(page.getSidenav().isDisplayed()).toBe(true);
-    });
-  });
 });

--- a/client/e2e/src/app.po.ts
+++ b/client/e2e/src/app.po.ts
@@ -8,15 +8,4 @@ export class AppPage {
   getAppTitle() {
     return element(by.className('app-title')).getText();
   }
-
-  openSideNav() {
-    return element(by.className('sidenav-button')).click();
-  }
-
-  getSidenav() {
-    return element(by.className('sidenav'));
-  }
-
-
-
 }

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -1,31 +1,7 @@
-<mat-sidenav-container class="sidenav-container">
-  <mat-sidenav #drawer class="sidenav" fixedInViewport mode="over">
-    <mat-toolbar>Menu</mat-toolbar>
-    <mat-nav-list class="sidenav-list">
+<mat-toolbar color="primary">
+  <span class="app-title">{{title}}</span>
+</mat-toolbar>
 
-      <!-- Side navigation links -->
-
-      <mat-list-item routerLink="/" routerLinkActive="drawer-list-item-active"
-      #routerLinkActiveInstance="routerLinkActive"
-      [attr.tabindex]="routerLinkActiveInstance.isActive ? 0 : -1"
-      [routerLinkActiveOptions]="{exact: true}" (click)="drawer.close()">
-      <mat-icon matListIcon>home</mat-icon>
-      Home
-      </mat-list-item>
-
-    </mat-nav-list>
-  </mat-sidenav>
-
-  <mat-sidenav-content>
-    <mat-toolbar color="primary">
-      <button type="button" aria-label="Toggle sidenav" mat-icon-button
-      (click)="drawer.toggle()" class="sidenav-button">
-        <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
-      </button>
-      <span class="app-title">{{title}}</span>
-    </mat-toolbar>
-    <div class="main-content mat-typography">
-      <router-outlet></router-outlet>
-    </div>
-  </mat-sidenav-content>
-</mat-sidenav-container>
+<div class="main-content mat-typography">
+  <router-outlet></router-outlet>
+</div>

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,6 +1,4 @@
 .mat-toolbar.mat-primary {
-  position: fixed;
-  top: 0;
   z-index: 1;
 }
 

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,5 +1,8 @@
 .mat-toolbar.mat-primary {
   z-index: 1;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 }
 
 .main-content {

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -1,25 +1,8 @@
-.sidenav-container {
-  height: 100%;
-}
-
-.sidenav {
-  width: 256px;
-}
-
-.sidenav .mat-toolbar {
-  background: inherit;
-}
-
 .mat-toolbar.mat-primary {
-  position: sticky;
+  position: fixed;
   top: 0;
   z-index: 1;
 }
-
-.app-title {
-  padding-left: 20px;
-}
-
 
 .main-content {
   margin: 24px;

--- a/client/src/app/app.component.scss
+++ b/client/src/app/app.component.scss
@@ -5,6 +5,10 @@
   justify-content: center;
 }
 
+.app-title {
+  font-size: larger;
+}
+
 .main-content {
   margin: 24px;
   @media (max-width: 599px) {


### PR DESCRIPTION
Also, re-style the titlebar a bit now that the nav-bar is gone.

There was only ever going to be one page in it, so it didn't have a reason to exist. Really, our app doesn't have that much in the way of navigation.